### PR TITLE
Code restructuring and extra flow/potential diagnostics

### DIFF
--- a/scripts/plot_flow_projections.py
+++ b/scripts/plot_flow_projections.py
@@ -561,7 +561,7 @@ def evaluate_loss(flow_list, eta_train, batch_size=1024):
     return loss_mean, loss_std
 
 
-def get_flow_ideal_dfdt(df_data, omega=0., v_0=np.array([0., 0., 0.]), r_c=8.3, grid_size=32):
+def get_flow_leastsq_dfdt(df_data, omega=0., v_0=np.array([0., 0., 0.]), r_c=8.3, grid_size=32):
     """ Returns a least-squares based estimate on the optimal value of \partial f / \partial t
     corresponding to the flow. This is done by binning the spatial space and optimizing for CBE
     """
@@ -676,7 +676,7 @@ def plot_flow_dfdt(df_data, dim1, dim2, omega, v_0, r_c, attrs, fig_dir, fig_fmt
     x_bins = np.linspace(xmin, xmax, 32)
     y_bins = np.linspace(ymin, ymax, 32)
     
-    theoretical_flow_dfdt = get_flow_ideal_dfdt(df_data, omega=omega, v_0=v_0, r_c=r_c, grid_size=32)
+    theoretical_flow_dfdt = get_flow_leastsq_dfdt(df_data, omega=omega, v_0=v_0, r_c=r_c, grid_size=32)
 
     # Flow ideal dfdt
     ret = binned_statistic_2d(eta[:, ix], eta[:, iy], theoretical_flow_dfdt, statistic=np.mean, bins=[x_bins, y_bins])

--- a/scripts/plot_flow_projections.py
+++ b/scripts/plot_flow_projections.py
@@ -435,7 +435,7 @@ def plot_2d_slice(coords_train, coords_sample, fig_dir, dim1, dim2, dimz, z, dz,
     norm = Normalize(vmin=0, vmax=np.max(nt)*n_sample/n_train)
     ns,_,_,_ = ax_s.hist2d(x_sample, y_sample, norm=norm, **kw)
 
-    if attrs is not None:
+    if attrs['has_spatial_cut']:
         add_2dpopulation_boundaries(axs, dim1, dim2, attrs)
 
 
@@ -597,7 +597,7 @@ def plot_1d_slice(coords_train, coords_sample, fig_dir, dim1, dimy, dimz, y, dy,
     ax_h.legend(loc='lower right', frameon=False, fontsize=8)
     ax_h.set_ylabel('frequency')
 
-    if attrs is not None:
+    if attrs['has_spatial_cut']:
         add_1dpopulation_boundaries([ax_h, ax_r], dim1, attrs)
 
     dn = ns/n_sample - nt/n_train
@@ -710,11 +710,6 @@ def main():
         help='Use dark background for figures.'
     )
     parser.add_argument(
-        '--show-attrs',
-        action='store_true',
-        help='Load attributes of the training data for visualisation (e.g. cut boundaries).'
-    )
-    parser.add_argument(
         '--autosave',
         action='store_true',
         help='Automatically saves/loads samples and chooses fig dir. Incompatible with save samples, load samples, and fig-dir.\
@@ -754,7 +749,7 @@ def main():
     eta_train = data_train['eta']
     n_train = eta_train.shape[0]
 
-    print(attrs_train, args.show_attrs)
+    print(attrs_train)
     print(f'  --> Training data shape = {eta_train.shape}')
 
     print('Loading flows ...')

--- a/scripts/plot_flow_projections.py
+++ b/scripts/plot_flow_projections.py
@@ -750,7 +750,7 @@ def main():
         args.fig_dir = fig_dir
 
     print('Loading training data ...')
-    data_train, attrs_train = utils.load_training_data(args.input)
+    data_train, attrs_train = utils.load_training_data(args.input, cut_attrs=True)
     eta_train = data_train['eta']
     n_train = eta_train.shape[0]
 

--- a/scripts/plot_gaia.py
+++ b/scripts/plot_gaia.py
@@ -32,7 +32,7 @@ import utils
 dpi = 200
 
 
-def plot_rho(phi_model, coords_train, fig_dir, dim1, dim2, dimz, z, padding=0.95, attrs=None, fig_fmt=('svg',), save=True): 
+def plot_rho(phi_model, coords_train, fig_dir, dim1, dim2, dimz, z, attrs, padding=0.95, fig_fmt=('svg',), save=True): 
     labels = [
         '$x\mathrm{\ [kpc]}$', '$y\mathrm{\ [kpc]}$', '$z\mathrm{\ [kpc]}$',
     ]
@@ -69,7 +69,7 @@ def plot_rho(phi_model, coords_train, fig_dir, dim1, dim2, dimz, z, padding=0.95
         return fig, axs
 
 
-def plot_force_2d_slice(phi_model, coords_train, fig_dir, dim1, dim2, dimz, z, padding=0.95, attrs=None, fig_fmt=('svg',), save=True): 
+def plot_force_2d_slice(phi_model, coords_train, fig_dir, dim1, dim2, dimz, z, attrs, padding=0.95, fig_fmt=('svg',), save=True): 
     labels = [
         '$x\mathrm{\ [kpc]}$', '$y\mathrm{\ [kpc]}$', '$z\mathrm{\ [kpc]}$',
     ]
@@ -110,7 +110,7 @@ def plot_force_2d_slice(phi_model, coords_train, fig_dir, dim1, dim2, dimz, z, p
         return fig, axs
     
     
-def plot_force_1d_slice(phi_model, coords_train, fig_dir, dim1, dimy, y, z, dimforce, padding=0.95, attrs=None, fig_fmt=('svg',), save=True): 
+def plot_force_1d_slice(phi_model, coords_train, fig_dir, dim1, dimy, y, z, dimforce, attrs, padding=0.95, fig_fmt=('svg',), save=True): 
     labels = [
         '$x\mathrm{\ [kpc]}$', '$y\mathrm{\ [kpc]}$', '$z\mathrm{\ [kpc]}$',
     ]
@@ -214,7 +214,7 @@ def plot_force_1d_slice(phi_model, coords_train, fig_dir, dim1, dimy, y, z, dimf
         return fig, ax
 
 
-def plot_dfdt_2d_marginal(phi_model, coords_train, df_data, dphi_dq, fig_dir, dim1, dim2, padding=0.95, attrs=None, fig_fmt=('svg',), save=True):
+def plot_dfdt_2d_marginal(phi_model, coords_train, df_data, dphi_dq, fig_dir, dim1, dim2, attrs, padding=0.95, fig_fmt=('svg',), save=True):
     fig,(all_axs) = plt.subplots(2, 3,
             figsize=(6,2.2),
             dpi=200,
@@ -309,7 +309,7 @@ def plot_dfdt_2d_marginal(phi_model, coords_train, df_data, dphi_dq, fig_dir, di
         return fig, axs  
 
 
-def plot_vcirc_marginals(phi_model, coords_train, coords_sample, fig_dir, attrs=None, fig_fmt=('svg',), save=True):    
+def plot_vcirc_marginals(phi_model, coords_train, coords_sample, fig_dir, attrs, fig_fmt=('svg',), save=True):    
     x_train, x_sample = coords_train['cylR'], coords_sample['cylR']
     y_train, y_sample = coords_train['cylvT'], coords_sample['cylvT']
 
@@ -361,7 +361,7 @@ def plot_vcirc_marginals(phi_model, coords_train, coords_sample, fig_dir, attrs=
     return
 
 
-def plot_vcirc_2d_slice(phi_model, coords_train, coords_sample, fig_dir, dim1, dim2, dimz, z, padding=0.95, attrs=None, fig_fmt=('svg',), save=True):
+def plot_vcirc_2d_slice(phi_model, coords_train, coords_sample, fig_dir, dim1, dim2, dimz, z, attrs, padding=0.95, fig_fmt=('svg',), save=True):
     labels = [
         '$x\mathrm{\ [kpc]}$', '$y\mathrm{\ [kpc]}$', '$z\mathrm{\ [kpc]}$',
     ]
@@ -494,7 +494,7 @@ def plot_vcirc_2d_slice(phi_model, coords_train, coords_sample, fig_dir, dim1, d
     return
 
 
-def plot_custom_potential_marginal(phi_model, fig_dir, dim1, quantity, padding=0.95, attrs=None, fig_fmt=('svg',), save=True): 
+def plot_custom_potential_marginal(phi_model, fig_dir, dim1, quantity, attrs, padding=0.95, fig_fmt=('svg',), save=True): 
     # Draws samples in the volume of validity, and bins them along a chosen axis
     # (TODO: Currently only z works). Works for the implied surface density
     # TODO: Only works with attributes
@@ -715,7 +715,7 @@ def main():
     ]
     for dim1, dim2, dimz, z in dims:
         print(f'  --> ({dim1}, {dim2})')
-        plot_rho(phi_model, coords_train, args.fig_dir, dim1, dim2, dimz, z, padding=0.95, attrs=attrs_train, fig_fmt=args.fig_fmt)
+        plot_rho(phi_model, coords_train, args.fig_dir, dim1, dim2, dimz, z, attrs=attrs_train, padding=0.95, fig_fmt=args.fig_fmt)
 
     
     print('Plotting 2D slices of forces ...')
@@ -726,7 +726,7 @@ def main():
     ]
     for dim1, dim2, dimz, z in dims:
         print(f'  --> ({dim1}, {dim2})')
-        plot_force_2d_slice(phi_model, coords_train, args.fig_dir, dim1, dim2, dimz, z, padding=0.95, attrs=attrs_train, fig_fmt=args.fig_fmt)
+        plot_force_2d_slice(phi_model, coords_train, args.fig_dir, dim1, dim2, dimz, z, attrs=attrs_train, padding=0.95, fig_fmt=args.fig_fmt)
 
 
     print('Plotting 1D slices of forces ...')
@@ -737,7 +737,7 @@ def main():
     ]
     for dim1, dimy, y, z, dimforce in dims:
         print(f'  --> ({dim1}, {dimy}={y}, {z})')
-        plot_force_1d_slice(phi_model, coords_train, args.fig_dir, dim1, dimy, y, z, dimforce, padding=0.95, attrs=attrs_train, fig_fmt=args.fig_fmt)
+        plot_force_1d_slice(phi_model, coords_train, args.fig_dir, dim1, dimy, y, z, dimforce, attrs=attrs_train, padding=0.95, fig_fmt=args.fig_fmt)
 
         
     print('Plotting 1D marginals of the potential ...')
@@ -747,7 +747,7 @@ def main():
     ]
     for dim1, quantity in dims:
         print(f'  --> ({dim1}: {quantity})')
-        plot_custom_potential_marginal(phi_model, args.fig_dir, dim1, quantity, padding=0.95, attrs=attrs_train, fig_fmt=args.fig_fmt)
+        plot_custom_potential_marginal(phi_model, args.fig_dir, dim1, quantity, attrs=attrs_train, padding=0.95, fig_fmt=args.fig_fmt)
 
     print('Plotting frameshift parameters evolution (might take a while) ...')
     plot_potential.plot_frameshift_params(args.potential, args.fig_dir, args.fig_fmt)
@@ -776,7 +776,7 @@ def main():
         ]
         for dim1, dim2, dimz, z in dims:
             print(f'  --> ({dim1}, {dim2}, {dimz}={z})')
-            plot_vcirc_2d_slice(phi_model, coords_gc_train, coords_gc_sample, fig_dir, dim1, dim2, dimz, z, padding=0.95, attrs=attrs_train, fig_fmt=args.fig_fmt)
+            plot_vcirc_2d_slice(phi_model, coords_gc_train, coords_gc_sample, fig_dir, dim1, dim2, dimz, z, attrs=attrs_train, padding=0.95, fig_fmt=args.fig_fmt)
 
         print('Plotting 2D slices of \partial f/\partial t ...')
         dims = [
@@ -788,7 +788,7 @@ def main():
         _, dphi_dq,_ = potential_tf.calc_phi_derivatives(phi_model['phi'], df_data['eta'][:,:3], return_phi=True)
         for dim1, dim2 in dims:
             print(f'  --> ({dim1}, {dim2})')
-            plot_dfdt_2d_marginal(phi_model, coords_train, df_data, dphi_dq, args.fig_dir, dim1, dim2, padding=0.95, attrs=attrs_train, fig_fmt=args.fig_fmt)
+            plot_dfdt_2d_marginal(phi_model, coords_train, df_data, dphi_dq, args.fig_dir, dim1, dim2, attrs=attrs_train, padding=0.95, fig_fmt=args.fig_fmt)
     else:
         print("Couldn't find df gradients.")
     

--- a/scripts/plot_potential.py
+++ b/scripts/plot_potential.py
@@ -30,8 +30,8 @@ dpi = 200
 
 
 
-def plot_rho(phi_model, coords_train, fig_dir, dim1, dim2, dimz, z, padding=0.95, attrs=None, fig_fmt=('svg',), save=True): 
-    """ TODO: only works with attrs at the moment, verbose not implemented. Only support cartesian.
+def plot_rho(phi_model, coords_train, fig_dir, dim1, dim2, dimz, z, attrs, padding=0.95, fig_fmt=('svg',), save=True): 
+    """ Only support cartesian.
     """
     labels = [
         '$x$', '$y$', '$z$',
@@ -174,7 +174,7 @@ def plot_rho(phi_model, coords_train, fig_dir, dim1, dim2, dimz, z, padding=0.95
         return fig, axs
 
 
-def plot_force_2d_slice(phi_model, coords_train, fig_dir, dim1, dim2, dimz, z, padding=0.95, attrs=None, fig_fmt=('svg',), save=True): 
+def plot_force_2d_slice(phi_model, coords_train, fig_dir, dim1, dim2, dimz, z, attrs, padding=0.95, fig_fmt=('svg',), save=True): 
     """ Only support cartesian.
     """
     labels = [
@@ -353,7 +353,7 @@ def plot_frameshift_params(fname, fig_dir, fig_fmt=('svg',)):
     plt.close(fig)
     
 
-def plot_force_1d_slice(phi_model, coords_train, fig_dir, dim1, dimy, y, z, dimforce, padding=0.95, attrs=None, fig_fmt=('svg',), save=True): 
+def plot_force_1d_slice(phi_model, coords_train, fig_dir, dim1, dimy, y, z, dimforce, attrs, padding=0.95, fig_fmt=('svg',), save=True): 
     """ Only supports cartesian.
     """
     labels = [
@@ -379,7 +379,6 @@ def plot_force_1d_slice(phi_model, coords_train, fig_dir, dim1, dimy, y, z, dimf
     
 
     # Get the plot limits
-    lims = []
     k = 0.2
     xlim = np.percentile(coords_train[dim1], [1., 99.])
     w = xlim[1] - xlim[0]
@@ -551,7 +550,7 @@ def main():
     ]
     for dim1, dim2, dimz, z in dims:
         print(f'  --> ({dim1}, {dim2})')
-        plot_rho(phi_model, coords_train, args.fig_dir, dim1, dim2, dimz, z, padding=0.95, attrs=attrs_train, fig_fmt=args.fig_fmt)
+        plot_rho(phi_model, coords_train, args.fig_dir, dim1, dim2, dimz, z, attrs=attrs_train, padding=0.95, fig_fmt=args.fig_fmt)
 
     
     print('Plotting 2D slices of forces ...')
@@ -562,7 +561,7 @@ def main():
     ]
     for dim1, dim2, dimz, z in dims:
         print(f'  --> ({dim1}, {dim2})')
-        plot_force_2d_slice(phi_model, coords_train, args.fig_dir, dim1, dim2, dimz, z, padding=0.95, attrs=attrs_train, fig_fmt=('pdf',))
+        plot_force_2d_slice(phi_model, coords_train, args.fig_dir, dim1, dim2, dimz, zattrs=attrs_train, padding=0.95, fig_fmt=('pdf',))
 
 
     print('Plotting 1D slices of forces ...')
@@ -573,7 +572,7 @@ def main():
     ]
     for dim1, dimy, y, z, dimforce in dims:
         print(f'  --> ({dim1})')
-        plot_force_1d_slice(phi_model, coords_train, args.fig_dir, dim1, dimy, y, z, dimforce, padding=0.95, attrs=attrs_train, fig_fmt=('pdf',))
+        plot_force_1d_slice(phi_model, coords_train, args.fig_dir, dim1, dimy, y, z, dimforce, attrs=attrs_train, padding=0.95, fig_fmt=('pdf',))
 
     print('Plotting frameshift parameters evolution (might take a while) ...')
     plot_frameshift_params(args.potential, args.fig_dir, args.fig_fmt)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -37,7 +37,10 @@ def load_training_data(fname, cut_attrs=False):
             is done for helping flow training by avoiding sharp cut-offs)
     """
     def cut(eta, attrs):
-        # Cuts eta based on attrs.
+        # Don't perform a cut if there is no attrs
+        if attrs == {}: return eta
+
+        # Cuts eta based on attrs
         r2 = np.sum(eta[:,:3]**2, axis=1)
         R2 = np.sum(eta[:,:2]**2, axis=1)
         abs_z = np.abs(eta[:,2])
@@ -57,8 +60,8 @@ def load_training_data(fname, cut_attrs=False):
     if ext in ('.h5', '.hdf5'):
         with h5py.File(fname, 'r') as f:
             attrs = dict(f['eta'].attrs.items())
+
             data['eta'] = f['eta'][:].astype('f4')
-            attrs['n'] = len(data['eta'])
 
             if cut_attrs: data['eta'] = cut(data['eta'], attrs)
             
@@ -71,6 +74,9 @@ def load_training_data(fname, cut_attrs=False):
                 if cut_attrs:
                     data['eta_train'] = cut(data['eta_train'], attrs)
                     data['eta_val'] = cut(data['eta_val'], attrs)
+
+            attrs['has_spatial_cut'] = True if attrs != {} else False
+            attrs['n'] = len(data['eta'])
     else:
         raise ValueError(f'Unrecognized input file extension: "{ext}"')
 


### PR DESCRIPTION
1. The methods for loading in training data, flow samples (previously called df_data), flows and potentials have all been moved to utils.py. This is because the methods were previously defined separately in many different scripts with slight inconsistencies.
2. Flow plotting has an additional diagnostic in the form of \partial f / \partial t inferred from least squares applied on spatial bins of flow samples. It serves to show how non-stationary the flows are.
3. Potential plotting also has a diagnostic comparing \partial f / \partial t inferred from the trained potential and the \partial f / \partial t from least squares.
4. All plotting routines now work with both attributes and without attributes. Instead of inferring the plotting limits from attributes, it now looks at the bottom and top percentiles of the training data.
5. The training data can now have a pre-defined train-val split. This is useful for example when the training data has duplicate datapoints (e.g. arising from upsampling).
6. Various small bug fixes.